### PR TITLE
Increase version of requests dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.egg-info/
+.idea
 __pycache__
 dist

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     author_email='konstantin.schubert@sennder.com',
     packages=find_packages(exclude=("tests",)),
     install_requires=[
-        'requests==2.20',
+        'requests==2.25',
         'djangorestframework>=3.9.4,<3.10',
     ],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-VERSION = '0.0.9'
+VERSION = '0.0.10'
 
 setup(
     name='sennder-events',


### PR DESCRIPTION
As part of https://senndergmh.atlassian.net/browse/EVA-39 I want to increase the version of `responses` used by tests (https://github.com/sennder/sennder/blob/development/requirements_dev.txt#L9) to remove some test warnings.

This has a higher version requirement for `requests`, which can't be simple increased in the monolith because it is pinned in this repository.

Therefore this PR bumps the `requests` version and adds a new release version.

Note : once merged, a new tag will have to be added too, I have not done that yet until the PR is accepted.